### PR TITLE
Update default CORS Anywhere proxy

### DIFF
--- a/lux-eye/src/pages/home/LoadFromElsewhere.tsx
+++ b/lux-eye/src/pages/home/LoadFromElsewhere.tsx
@@ -5,7 +5,7 @@ import { useStore } from '../../store';
 import { notifyError } from '../../utils/notifications';
 import { HomeCard } from './HomeCard';
 
-const DEFAULT_PROXY = 'https://lux-eye-s2-cors-anywhere.jmerle.dev/';
+const DEFAULT_PROXY = 'https://lux-eye-s3-cors-anywhere.jmerle.dev/';
 
 const useStyles = createStyles(() => ({
   submitButton: {


### PR DESCRIPTION
I'm not sure how you want to handle the CORS Anywhere proxy in the visualizer this season, but I'd be happy to run it again. I like to separate my CORS Anywhere instances by project, and have origin whitelists on all of them to prevent abuse, so last season's proxy will no longer work. This PR changes the default CORS Anywhere proxy URL to https://lux-eye-s3-cors-anywhere.jmerle.dev/, which has http://localhost:5173, https://lux-eye-s3.netlify.app, and https://s3vis.lux-ai.org as whitelisted origins.

Please close this PR without merging in case me hosting the CORS Anywhere proxy for this season makes me ineligible for this season's prizes.