### PR TITLE
Cast map_features energy to int16

### DIFF
--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -45,7 +45,7 @@ class LuxAIS3Env(environment.Environment):
             return jnp.where(mask, lax.switch(fn_i.astype(jnp.int16), ENERGY_NODE_FNS, distances_to_node, x, y, z), jnp.zeros_like(distances_to_node))
         energy_field = jax.vmap(compute_energy_field)(state.energy_node_fns, distances_to_nodes, state.energy_nodes_mask)
         energy_field = jnp.where(energy_field.mean() < .25, energy_field + (.25 - energy_field.mean()), energy_field)
-        energy_field = jnp.round(energy_field.sum(0))
+        energy_field = jnp.round(energy_field.sum(0)).astype(jnp.int16)
         energy_field = jnp.clip(energy_field, params.min_energy_per_tile, params.max_energy_per_tile)
         state = state.replace(map_features=state.map_features.replace(energy=energy_field))
         return state


### PR DESCRIPTION
Potential solution to #18 - question: is there any reason for state.map_features.energy to be float32?