### PR TITLE
cast default params to jax arrays

### DIFF
--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -37,8 +37,7 @@ class LuxAIS3Env(environment.Environment):
     @property
     def default_params(self) -> EnvParams:
         params = EnvParams()
-        for k,v in params.__dict__.items():
-            params.__dict__[k] = jax.numpy.array(v)
+        params = jax.tree_map(jax.numpy.array, params)
         return params
 
     def compute_unit_counts_map(self, state: EnvState, params: EnvParams):

--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -36,7 +36,10 @@ class LuxAIS3Env(environment.Environment):
 
     @property
     def default_params(self) -> EnvParams:
-        return EnvParams()
+        params = EnvParams()
+        for k,v in params.__dict__.items():
+            params.__dict__[k] = jax.numpy.array(v)
+        return params
 
     def compute_unit_counts_map(self, state: EnvState, params: EnvParams):
         # map of total units per team on each tile, shape (num_teams, map_width, map_height)


### PR DESCRIPTION
Stepping over `LuxAIS3Env` with params set to `None` will always crash, because of cast `.astype(jnp.float32)` added. By default parameters are ints and they don't have this method.

Example code that crashes:
```py
import jax
from jax import numpy as jnp
from env import LuxAIS3Env
import numpy as np

observations = []

if __name__ == "__main__":
    max_steps = 505
    # batch_size = 4
    seed = 1    
    jax.config.update("jax_platform_name", "cpu") # "cpu" or "gpu"
    
    env = LuxAIS3Env(auto_reset=False)
    key = jax.random.key(seed)
    keys = jax.random.split(key, 2)

    key, [reset_key] = keys[0], keys[1:]
    obs, state = env.reset(reset_key)
    observations.append(obs)

    for i in range(max_steps):
        keys = jax.random.split(key, 2)
        key, [step_key] = keys[0], keys[1:]

        random_direction = np.random.randint(0, 5, size=(16, 1))
        zeros = np.zeros((16, 2), dtype=np.int16)
        actions = np.concat([random_direction, zeros], axis=-1)

        actions = {f"player_{i}": actions for i in range(2)}
        obs, state, reward, terminated_dict, truncated_dict, info = env.step(step_key, state, actions)
        # print(i, reward)
        observations.append(obs)
  ```
  Resulting error:
  ```
    File "/home/pokropow/programming/Lux-Design-S3/src/luxai_s3/env.py", line 379, in sap_unit
    params.unit_sap_cost.astype(jnp.float32)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'astype'
```

To fix this simply cast default parameters to jax arrays.