### PR TITLE
feat: add optional limit to tournament episodes

### DIFF
--- a/src/luxai_runner/cli.py
+++ b/src/luxai_runner/cli.py
@@ -46,6 +46,8 @@ class Args:
     """Max concurrent number of episodes to run. Recommended to set no higher than the number of CPUs / 2"""
     tournament_cfg_ranking_system: str = "elo"
     """The ranking system to use. Default is 'elo'. Can be 'elo', 'wins'."""
+    tournament_cfg_max_episodes: Optional[int] = None
+    """Maximum number of episodes to play in tournament mode. None means unlimited."""
     # skip_validate_action_space: bool = False
     # """Set this for a small performance increase. Note that turning this on means the engine assumes your submitted actions are valid. If your actions are not well formatted there could be errors"""
 
@@ -109,6 +111,9 @@ def main():
         )
         tournament_config.ranking_system = getattr(
             args, "tournament_cfg_ranking_system"
+        )
+        tournament_config.max_episodes = getattr(
+            args, "tournament_cfg_max_episodes"
         )
         tourney = Tournament(
             cfg=tournament_config, episode_cfg=cfg  # the base/default episode config

--- a/src/luxai_runner/tournament/config.py
+++ b/src/luxai_runner/tournament/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -15,3 +15,4 @@ class TournamentConfig:
     agents_per_episode: List[int] = field(default_factory=lambda: [2])
 
     max_concurrent_episodes: int = 4
+    max_episodes: Optional[int] = None


### PR DESCRIPTION
```bash
# no limit
luxai-s3 kits/python/main.py kits/python/main.py --tournament

# limit to total 10 episodes
luxai-s3 kits/python/main.py kits/python/main.py --tournament --tournament_cfg_max_episodes 10
```

To run about 30 episodes each for 5 agents, you would set limit to `5*30/2=75` episodes in total.

I can also add a `current episodes / max episodes` in the ranking, apart from `1 episodes are running` if you like that.