### PR TITLE
Cast sap_cost to float array to allow non-jit execution

### DIFF
--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -378,7 +378,7 @@ class LuxAIS3Env(environment.Environment):
                             & (other_units_adjacent_sapped_count[:, :, None] > 0),
                             all_units.energy[other_team_ids]
                             - jnp.array(
-                                params.unit_sap_cost.astype(jnp.float32)
+                                jnp.array(params.unit_sap_cost, dtype=jnp.float32)
                                 * params.unit_sap_dropoff_factor
                                 * other_units_adjacent_sapped_count[:, :, None].astype(jnp.float32),
                                 dtype=jnp.int16,


### PR DESCRIPTION
If we turn off jit, the parameter unit_sap_cost will be an int and .astype will fail. With this change, we can use non-jitted step() for debugging.