### PR TITLE
Correctly clip energy node movement to edge of board

### DIFF
--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -667,7 +667,10 @@ class LuxAIS3Env(environment.Environment):
         new_energy_nodes = jnp.clip(
             state.energy_nodes + energy_node_deltas,
             min=jnp.array([0, 0], dtype=jnp.int16),
-            max=jnp.array([self.fixed_env_params.map_width, self.fixed_env_params.map_height], dtype=jnp.int16),
+            max=jnp.array(
+                [self.fixed_env_params.map_width - 1, self.fixed_env_params.map_height - 1],
+                dtype=jnp.int16
+            ),
         )
         new_energy_nodes = jnp.where(
             state.steps * params.energy_node_drift_speed % 1 == 0,


### PR DESCRIPTION
The energy nodes currently clip to (0, 0) and (24, 24), but to maintain symmetry they should clip to (0, 0) and (23, 23). I think this may be related to issue https://github.com/Lux-AI-Challenge/Lux-Design-S3/issues/30.