### PR TITLE
Fix loading instructions on visualizer homepage

### DIFF
--- a/lux-eye/src/pages/home/LoadFromElsewhere.tsx
+++ b/lux-eye/src/pages/home/LoadFromElsewhere.tsx
@@ -125,9 +125,9 @@ export function LoadFromElsewhere(): JSX.Element {
       <Text mb="xs">
         Supported inputs:
         <List>
-          <List.Item>Kaggle episode ids, like <a href="#" onClick={copyToInput}>46550729</a>.</List.Item>
-          <List.Item>Kaggle leaderboard URLs, like <a href="#" onClick={copyToInput}>https://www.kaggle.com/competitions/lux-ai-season-2/leaderboard?dialog=episodes-episode-46550729</a>.</List.Item>
-          <List.Item>URLs to JSON episode data, like <a href="#" onClick={copyToInput}>https://www.kaggleusercontent.com/episodes/46550729.json</a>.</List.Item>
+          <List.Item>Kaggle episode ids, like <a href="#" onClick={copyToInput}>58306841</a>.</List.Item>
+          <List.Item>Kaggle leaderboard URLs, like <a href="#" onClick={copyToInput}>https://www.kaggle.com/competitions/lux-ai-season-3/leaderboard?dialog=episodes-episode-58306841</a>.</List.Item>
+          <List.Item>URLs to JSON episode data, like <a href="#" onClick={copyToInput}>https://www.kaggleusercontent.com/episodes/58306841.json</a>.</List.Item>
         </List>
       </Text>
 

--- a/lux-eye/src/pages/home/LoadFromKaggle.tsx
+++ b/lux-eye/src/pages/home/LoadFromKaggle.tsx
@@ -7,7 +7,7 @@ export function LoadFromKaggle(): JSX.Element {
       {/* prettier-ignore */}
       <Text>
         Episodes can be loaded straight from Kaggle notebooks.
-        See the <a href="https://www.kaggle.com/code/jmerle/lux-eye-2022-integration" target="_blank" rel="noreferrer">Lux Eye 2022 integration</a> notebook for instructions.
+        See the <a href="https://www.kaggle.com/code/jmerle/lux-eye-s3-notebook-integration" target="_blank" rel="noreferrer">example notebook</a> for instructions.
       </Text>
     </HomeCard>
   );

--- a/lux-eye/src/store.ts
+++ b/lux-eye/src/store.ts
@@ -162,10 +162,8 @@ export const useStore = create(
         set({ loading: true, progress: 0 });
 
         const interestingPrefixes = [
-          'https://www.kaggle.com/competitions/lux-ai-2022-beta/leaderboard?dialog=episodes-episode-',
-          'https://www.kaggle.com/competitions/lux-ai-2022-beta/submissions?dialog=episodes-episode-',
-          'https://www.kaggle.com/competitions/lux-ai-season-2/leaderboard?dialog=episodes-episode-',
-          'https://www.kaggle.com/competitions/lux-ai-season-2/submissions?dialog=episodes-episode-',
+          'https://www.kaggle.com/competitions/lux-ai-season-3/leaderboard?dialog=episodes-episode-',
+          'https://www.kaggle.com/competitions/lux-ai-season-3/submissions?dialog=episodes-episode-',
         ];
 
         let url: string;


### PR DESCRIPTION
- Changed the "Loading from Kaggle" instructions to link to [a notebook of mine](https://www.kaggle.com/code/jmerle/lux-eye-s3-notebook-integration) displaying how to render completed episodes in the notebook-friendly version of the notebook, based on my [similar notebook from last season](https://www.kaggle.com/code/jmerle/lux-eye-2022-integration).
- Fixed the "Load from elsewhere" section to include examples of inputs from this season rather than last season, and fixed an issue where you couldn't load leaderboard URLs from this season.