### PR TITLE
Add Fog of War functionality to visualizer

### DIFF
--- a/lux-eye/src/pages/visualizer/Board.tsx
+++ b/lux-eye/src/pages/visualizer/Board.tsx
@@ -10,10 +10,18 @@ interface SizeConfig {
   boardSize: number;
   tilesPerSide: number;
 }
+
+export enum FogOfWar {
+  Both,
+  Team1,
+  Team2,
+  None,
+}
 export interface DisplayConfig {
   energyField: boolean;
   sensorMask: boolean;
   relicConfigs: boolean;
+  fogOfWar: FogOfWar;
 }
 interface ThemeConfig {
   minimalTheme: boolean;
@@ -53,11 +61,32 @@ function tileToCanvas(sizes: SizeConfig, tile: Tile): [number, number] {
 //   return (clampedValue - relativeMin) / (relativeMax - relativeMin);
 // }
 
+function fogOfWarForTile(step: Step, tileX: number, tileY: number): boolean {
+  const fogOfWar = useStore.getState().displayConfig.fogOfWar;
+  const skipTeam1 = !step.teams[0].sensorMask[tileX][tileY];
+  const skipTeam2 = !step.teams[1].sensorMask[tileX][tileY];
+
+  switch (fogOfWar) {
+    case FogOfWar.None:
+      return false;
+    case FogOfWar.Both:
+      return skipTeam1 && skipTeam2;
+    case FogOfWar.Team1:
+      return skipTeam1;
+    case FogOfWar.Team2:
+      return skipTeam2;
+  }
+}
+
 function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step: Step, envParams: EnvParams): void {
   const board = step.board;
 
   for (let tileY = 0; tileY < config.tilesPerSide; tileY++) {
     for (let tileX = 0; tileX < config.tilesPerSide; tileX++) {
+      const skip = fogOfWarForTile(step, tileX, tileY);
+      if (skip) {
+        continue;
+      }
       const [canvasX, canvasY] = tileToCanvas(config, { x: tileX, y: tileY });
 
       ctx.fillStyle = 'white';
@@ -107,13 +136,16 @@ function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step
   for (let i = 0; i < board.relicNodes.length; i++) {
     const [canvasX, canvasY] = tileToCanvas(config, { x: board.relicNodes[i][0], y: board.relicNodes[i][1] });
 
-    ctx.fillStyle = 'orange';
-    ctx.fillRect(
-      canvasX + config.tileSize / 4,
-      canvasY + config.tileSize / 4,
-      config.tileSize / 2,
-      config.tileSize / 2,
-    );
+    if (!fogOfWarForTile(step, board.relicNodes[i][0], board.relicNodes[i][1])) {
+      ctx.fillStyle = 'orange';
+      ctx.fillRect(
+        canvasX + config.tileSize / 4,
+        canvasY + config.tileSize / 4,
+        config.tileSize / 2,
+        config.tileSize / 2,
+      );
+    }
+
     if (config.relicConfigs) {
       for (
         let dx = -Math.floor(envParams.relic_config_size / 2);
@@ -128,6 +160,9 @@ function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step
           const nx = board.relicNodes[i][0] + dx;
           const ny = board.relicNodes[i][1] + dy;
           if (nx < 0 || nx >= config.tilesPerSide || ny < 0 || ny >= config.tilesPerSide) {
+            continue;
+          }
+          if (fogOfWarForTile(step, nx, ny)) {
             continue;
           }
           if (
@@ -157,11 +192,17 @@ function drawTileBackgrounds(ctx: CanvasRenderingContext2D, config: Config, step
 
 function drawRobot(
   ctx: CanvasRenderingContext2D,
+  step: Step,
   config: Config,
   robot: Robot,
   team: number,
   selectedTile: Tile | null,
 ): void {
+  const skip = fogOfWarForTile(step, robot.tile.x, robot.tile.y);
+  if (skip) {
+    return;
+  }
+
   const [canvasX, canvasY] = tileToCanvas(config, robot.tile);
 
   const isSelected = selectedTile !== null && robot.tile.x === selectedTile.x && robot.tile.y === selectedTile.y;
@@ -255,7 +296,7 @@ function drawBoard(
   }
   for (let i = 0; i < 2; i++) {
     for (const robot of step.teams[i].robots) {
-      drawRobot(ctx, config, robot, i, selectedTile);
+      drawRobot(ctx, step, config, robot, i, selectedTile);
     }
   }
   robotPositions.forEach((count, key) => {

--- a/lux-eye/src/pages/visualizer/TurnControl.tsx
+++ b/lux-eye/src/pages/visualizer/TurnControl.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Kbd, Slider, Stack, Table, Text } from '@mantine/core';
+import { ActionIcon, Button, Group, Kbd, Menu, Slider, Stack, Table, Text } from '@mantine/core';
 import { HotkeyItem, useElementSize, useHotkeys } from '@mantine/hooks';
 import { useModals } from '@mantine/modals';
 import {
@@ -15,6 +15,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getMatchIdx, parseTileType } from '../../episode/luxai';
 import { useStore } from '../../store';
+import { FogOfWar } from './Board';
 
 const SPEEDS = [0.5, 1, 2, 4, 8, 16, 32];
 
@@ -135,6 +136,16 @@ export function TurnControl({ showHotkeysButton, showOpenButton }: TurnControlPr
     });
   }, [displayConfig]);
 
+  const setFogOfWar = useCallback(
+    (fogOfWar: FogOfWar) => {
+      setDisplayConfig({
+        ...displayConfig,
+        fogOfWar,
+      });
+    },
+    [displayConfig],
+  );
+
   const previousTurn = useCallback(() => {
     if (turn > 0 && !sliderRef.current?.contains(document.activeElement)) {
       setTurn(turn - 1);
@@ -247,11 +258,9 @@ export function TurnControl({ showHotkeysButton, showOpenButton }: TurnControlPr
 
   const openJsonDataModal = useCallback(() => {
     modals.openModal({
-      title: 'This Game\'s Parameters',
+      title: "This Game's Parameters",
       size: 'auto',
-      children: (
-        <pre>{JSON.stringify(episode.params, null, 2)}</pre>
-      ),
+      children: <pre>{JSON.stringify(episode.params, null, 2)}</pre>,
     });
   }, [episode]);
 
@@ -334,6 +343,20 @@ export function TurnControl({ showHotkeysButton, showOpenButton }: TurnControlPr
         <ActionIcon color="blue" variant="transparent" title="Show JSON data" onClick={openJsonDataModal}>
           <IconInfoCircle />
         </ActionIcon>
+        <Menu shadow="md" width={200}>
+          <Menu.Target>
+            <Button color="blue" variant={displayConfig.fogOfWar == FogOfWar.None ? 'outline' : 'filled'} size="xs">
+              FOW
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Label>Set Fog of War</Menu.Label>
+            <Menu.Item onClick={() => setFogOfWar(FogOfWar.None)}>None</Menu.Item>
+            <Menu.Item onClick={() => setFogOfWar(FogOfWar.Team1)}>Team 1</Menu.Item>
+            <Menu.Item onClick={() => setFogOfWar(FogOfWar.Team2)}>Team 2</Menu.Item>
+            <Menu.Item onClick={() => setFogOfWar(FogOfWar.Both)}>Both</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
 
         <div style={{ marginRight: 'auto' }} />
 
@@ -355,15 +378,21 @@ export function TurnControl({ showHotkeysButton, showOpenButton }: TurnControlPr
 
       {selectedTile !== null && (
         <Group position="apart">
-          <Text>Tile Type: {parseTileType(step.board.tileType[selectedTile.x][selectedTile.y])} {step.board.energyNodes.find((val) => {
-            return val[0] == selectedTile.x && val[1] == selectedTile.y
-          }) && "(Energy Node)"} {step.board.relicNodes.find((val) => {
-            return val[0] == selectedTile.x && val[1] == selectedTile.y
-          }) && "(Relic Node)"}</Text>
-          
-          
+          <Text>
+            Tile Type: {parseTileType(step.board.tileType[selectedTile.x][selectedTile.y])}{' '}
+            {step.board.energyNodes.find(val => {
+              return val[0] == selectedTile.x && val[1] == selectedTile.y;
+            }) && '(Energy Node)'}{' '}
+            {step.board.relicNodes.find(val => {
+              return val[0] == selectedTile.x && val[1] == selectedTile.y;
+            }) && '(Relic Node)'}
+          </Text>
+
           <Text>Energy: {step.board.energy[selectedTile.x][selectedTile.y]}</Text>
-          <Text>Vision Power: {step.board.visionPowerMap[0][selectedTile.x][selectedTile.y]}, {step.board.visionPowerMap[1][selectedTile.x][selectedTile.y]}</Text>
+          <Text>
+            Vision Power: {step.board.visionPowerMap[0][selectedTile.x][selectedTile.y]},{' '}
+            {step.board.visionPowerMap[1][selectedTile.x][selectedTile.y]}
+          </Text>
         </Group>
       )}
 

--- a/lux-eye/src/store.ts
+++ b/lux-eye/src/store.ts
@@ -4,7 +4,7 @@ import { persist } from 'zustand/middleware';
 import { isKaggleEnvironmentsEpisode, parseKaggleEnvironmentsEpisode } from './episode/kaggle-environments';
 import { isLuxAISEpisode, parseLuxAISEpisode } from './episode/luxai';
 import { Episode, Tile } from './episode/model';
-import { DisplayConfig } from './pages/visualizer/Board';
+import { DisplayConfig, FogOfWar } from './pages/visualizer/Board';
 
 const PRODUCTION_BASE_URL = 'https://s3vis.lux-ai.org';
 
@@ -59,6 +59,7 @@ export const useStore = create(
         sensorMask: true,
         energyField: false,
         relicConfigs: true,
+        fogOfWar: FogOfWar.Both,
       },
       minimalTheme: true,
 
@@ -236,6 +237,9 @@ export const useStore = create(
       },
       setDisplayConfig: (displayConfig: DisplayConfig) => {
         set({ displayConfig });
+      },
+      setFogOfWar: (fogOfWar: FogOfWar) => {
+        set(state => ({ displayConfig: { ...state.displayConfig, fogOfWar } }));
       },
     }),
     {


### PR DESCRIPTION
Add fog of war pov for both teams individually and together.

# Screenshots of Different Modes

| **Both Team FOW** | **Team 2 FOW** |
|------------|-------------|
| ![Screenshot 2024-12-29 135442](https://github.com/user-attachments/assets/21c29ef8-d6fa-424b-9aa3-d7f0713c9e07) | ![Screenshot 2024-12-29 135434](https://github.com/user-attachments/assets/6ab06f34-de21-4b75-b93d-d5734b45f8c6) |

| **Team 1 FOW** | **No FOW** |
|------------|-------------|
| ![Screenshot 2024-12-29 135423](https://github.com/user-attachments/assets/49d831c6-ffa9-4a66-b172-1c607900b1e1) | ![Screenshot 2024-12-29 135359](https://github.com/user-attachments/assets/0059a8b9-83e4-4dd0-a18f-08ef269c7772) |
