### PR TITLE
bugfix relic_nodes_map_weights initialization

### DIFF
--- a/src/luxai_s3/state.py
+++ b/src/luxai_s3/state.py
@@ -206,7 +206,7 @@ def gen_state(key: chex.PRNGKey, env_params: EnvParams, max_units: int, num_team
                     relic_nodes_map_weights <= relic_node_id + 1
                 )
                 relic_nodes_map_weights = jnp.where(
-                    valid_pos & mask & jnp.logical_not(has_points),
+                    valid_pos & mask & jnp.logical_not(has_points) & relic_node_config[dx, dy],
                     relic_nodes_map_weights.at[x, y].set(relic_node_config[dx, dy].astype(jnp.int16) * (relic_node_id + 1)),
                     relic_nodes_map_weights,
                 )


### PR DESCRIPTION
This should fix the bugs mentioned [here](https://www.kaggle.com/competitions/lux-ai-season-3/discussion/558186) and [here](https://www.kaggle.com/competitions/lux-ai-season-3/discussion/558173), caused by later relic node point map initialization overwriting previous positive-valued point tiles with 0-valued point tiles.