### PR TITLE
Fix high boundary action space

### DIFF
--- a/src/luxai_s3/env.py
+++ b/src/luxai_s3/env.py
@@ -921,7 +921,7 @@ class LuxAIS3Env(environment.Environment):
         """Action space of the environment."""
         low = np.zeros((self.fixed_env_params.max_units, 3))
         low[:, 1:] = -env_params_ranges["unit_sap_range"][-1]
-        high = np.ones((self.fixed_env_params.max_units, 3)) * 6
+        high = np.ones((self.fixed_env_params.max_units, 3)) * 5
         high[:, 1:] = env_params_ranges["unit_sap_range"][-1]
         return spaces.Dict(
             dict(player_0=MultiDiscrete(low, high), player_1=MultiDiscrete(low, high))

--- a/src/luxai_s3/wrappers.py
+++ b/src/luxai_s3/wrappers.py
@@ -25,7 +25,7 @@ class LuxAIS3GymEnv(gym.Env):
 
         low = np.zeros((self.env_params.max_units, 3))
         low[:, 1:] = -self.env_params.unit_sap_range
-        high = np.ones((self.env_params.max_units, 3)) * 6
+        high = np.ones((self.env_params.max_units, 3)) * 5
         high[:, 1:] = self.env_params.unit_sap_range
         self.action_space = gym.spaces.Dict(
             dict(


### PR DESCRIPTION
According to the spec, the possible action values are: 0, 1, 2, 3, 4, 5.

`gymnasium.spaces.Box` has `low` and `high` parameters as inclusive boundaries of actions.

I've spotted this bug after having game with trained agent and feeding it to the HTML player.